### PR TITLE
Handle Windows line ending

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ function addDefaultCA(file) {
   try {
     var cert, match;
     var content = fs.readFileSync(file, { encoding: "ascii" }).trim();
+    content = content.replace(/\r\n/g, '\n'); // Handles certificates that have been created in Windows
     var regex = /-----BEGIN CERTIFICATE-----\n[\s\S]+?\n-----END CERTIFICATE-----/g;
     var results = content.match(regex);
+    if (!results) throw new Error('Could not parse certificate');
     results.forEach(function(match) {
       var cert = match.trim();
       rootCAs.push(cert);


### PR DESCRIPTION
When exporting a PEM certificate from Firefox (and maybe other browsers) in Windows, the file has `\r\n` line endings instead of `\n`, which means valid certificates resulted in the error `failed reading file test.pem: Cannot read property 'forEach' of null`.

This pull request converts the line endings before processing the certificate.

Also fixed the error message to give a bit more information.