### PR TITLE
Validate `options` parameter exists when calling tls.createSecureContext

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ if (useTrap) {
   const origCreateSecureContext = tls.createSecureContext;
   tls.createSecureContext = function(options) {
     var c = origCreateSecureContext.apply(null, arguments);
-    if (!options.ca && rootCAs.length > 0) {
+    if (!(options && options.ca) && rootCAs.length > 0) {
       rootCAs.forEach(function(ca) {
         // add to the created context our own root CAs
         c.context.addCACert(ca);


### PR DESCRIPTION
According to node.js documentation `options` parameter of tls.createSecureContext is optional.
Added validation to avoid reading property of undefined